### PR TITLE
Add support for pagedjs-cli as PDF engine

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,13 +19,8 @@ jobs:
       - name: Setup Pandoc
         run: brew install pandoc pandoc-crossref
 
-      - name: Setup TinyTeX
-        uses: r-lib/actions/setup-tinytex@v1
-
-      - name: TeX Dependencies
-        run: |
-          tlmgr --version
-          tlmgr install $(cat lib/latex-packages.txt)
+      - name: Setup PagedJS-CLI
+        run: npm install -g pagedjs-cli pagedjs 
 
       - name: Build Website
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 public
 _temp
+test

--- a/lantern.sh
+++ b/lantern.sh
@@ -15,7 +15,7 @@ output_formats() {
 
 # utilities
 
-pandoc_command='pandoc --verbose' # change to 'pandoc --quiet' for fewer logging messages
+pandoc_command='pandoc --quiet' # change to 'pandoc --verbose' for debugging
 
 # setup
 
@@ -71,35 +71,13 @@ convert_to_markdown() {
 
 # lantern output formats
 
-pdf_context() {
-    # combine all markdown files into one
-    $pandoc_command text/*.md -o _temp/chapters.md
-    # convert markdown to ConTeXt
-    $pandoc_command _temp/chapters.md \
-        --to context \
-        --defaults settings/context.yml \
-        --output $output_directory/$output_filename.tex
-    # convert ConTeXt to PDF    
-    $pandoc_command _temp/chapters.md \
-        --to context \
-        --defaults settings/context.yml \
-        --output $output_directory/$output_filename.pdf
-    echo "📖 The PDF edition is now available in the $output_directory folder"
-}
-
 pdf() {
     # combine all markdown files into one
     $pandoc_command text/*.md -o _temp/chapters.md
-    # convert markdown to LaTeX
+    # convert markdown to HTML to PDF
     $pandoc_command _temp/chapters.md \
-        --to latex \
-        --defaults settings/latex.yml \
-        --output $output_directory/$output_filename.tex
-    # convert LaTeX to PDF    
-    $pandoc_command _temp/chapters.md \
-        --to latex \
-        --defaults settings/latex.yml \
-        --output $output_directory/$output_filename.pdf
+        --defaults settings/pdf.yml \
+        --output  $output_directory/$output_filename.pdf
     echo "📖 The PDF edition is now available in the $output_directory folder"
 }
 

--- a/lib/css/pdf.css
+++ b/lib/css/pdf.css
@@ -1,0 +1,92 @@
+/* body{
+    --bleed: 6mm;
+}
+*/
+@media print {
+
+    body{
+        font-size: 11px;
+        font-family: 'Source Serif 4', sans-serif;
+        counter-reset: chapterNumber;
+    }
+
+    h1, h2, h3, h4, h5, h6 { font-weight: 700; }
+
+    h1 { font-size: 2rem; }
+    h2 { font-size: 1.75rem; }
+    h3 { font-size: 1.5rem; }
+    h4 { font-size: 1.25rem; }
+    h4 { font-size: 1.125rem; }
+
+    main > h2 { counter-increment: chapterNumber; }
+
+    main > h2::before { content: counter(chapterNumber) ". "; }
+
+    main > h2 {  string-set: title content(text) }
+
+    div.csl-entry {
+        margin-left:2em;
+        text-indent:-2em;
+        margin-bottom: 1em;
+    }
+
+    a {
+        color: #4f5a65;
+    }
+
+    pre, code { font-family: "Consolas, monospace" }
+
+    ul li {
+        list-style: none;
+    }
+    
+    ul li, ol li { margin-bottom: calc(1.5rem * 0.25); }
+
+    /* ALL PAGES ----------------------------------------------------------------------- */
+
+    @page {
+        size: A4;
+        margin: 1in;
+        @bottom-center {
+            content: counter(page);
+            text-align: center;
+        }
+        @top-center {
+            content: string(title)
+        }
+    }
+
+    /* BREAKS ----------------------------------------------------------------------- */
+
+
+    .title-page { break-after: page;}
+    .copyright-page { break-after: page; }
+    .table-of-contents { break-after: page; }
+
+    main > h2 { break-before: page; }
+
+
+
+    /* BLANK PAGES --------------------------------------------------------------------- */
+
+     @page :blank {
+        @bottom-left { content: none; }
+        @bottom-center { content: none; }
+        @bottom-right { content: none; }
+    }
+
+    /* NAMED PAGES --------------------------------------------------------------------- */
+
+    #title,
+    #copyright,
+    #toc { 
+        page: frontmatter; 
+    }
+
+    @page frontmatter {
+        @bottom-left { content: none; }
+        @bottom-center { content: none; }
+        @bottom-right { content: none; }
+    }
+
+}

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,7 +1,8 @@
 # bibliographic metadata
 
 title: Title
-author: Author
+author: 
+  - Author
 
 description: |
   Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.

--- a/settings/config.yml
+++ b/settings/config.yml
@@ -23,30 +23,3 @@ link-citations: true
 #    link: text.xml
 #  - label: Source
 #    link: https://github.com/USERNAME/REPOSITORY-NAME
-
-# LaTeX settings
-
-paper:
-  # available units: in, cm, or mm
-  # default creates A4 page size, > 150 pages long
-  width: 8.27in
-  height: 11.69in
-  gutter: 1in
-  margin:
-    top: 1in
-    bottom: 1in
-    left: 1in
-    right: 1in
-
-# ConTeXt settings
-
-papersize: a4 # a4, a5, letter
-fontsize: 12pt
-mainfont: DejaVu serif
-sansfont: DejaVu sans
-monofont: DejaVu sansmono
-mathfont: Latin Modern Math
-# available fonts: https://wiki.contextgarden.net/ConTeXt_distribution%27s_Fonts
-linkcolor: Sapphire 
-# available colors: https://wiki.contextgarden.net/Color#Crayola_crayon_colors
-linkstyle: bold # normal, bold, slanted, boldslanted, type, cap, small

--- a/settings/context.yml
+++ b/settings/context.yml
@@ -1,3 +1,6 @@
+# DEPRECATED: earlier versions of Lantern supported ConTeXt, but no longer
+# leaving this here in case you prefer ConTeXt as your PDF engine
+
 from: markdown
 # reader: may be used instead of from:
 to: context

--- a/settings/latex.yml
+++ b/settings/latex.yml
@@ -1,3 +1,6 @@
+# DEPRECATED: earlier versions of Lantern supported LaTeX, but no longer
+# leaving this here in case you prefer LaTeX as your PDF engine
+
 # pandoc settings for html output format
 # for all available options, see 
 # https://pandoc.org/MANUAL.html#default-files

--- a/settings/pdf.yml
+++ b/settings/pdf.yml
@@ -31,7 +31,7 @@ toc-depth: 3
 number-sections: false
 
 # citations
-citeproc: true
+citeproc: false
 bibliography:
   - references.bib
 

--- a/settings/pdf.yml
+++ b/settings/pdf.yml
@@ -1,0 +1,49 @@
+# pandoc settings for html output format
+# for all available options, see 
+# https://pandoc.org/MANUAL.html#default-files
+
+metadata-file: 
+  - metadata.yml
+  - settings/config.yml
+  
+from: markdown
+to: html5
+
+template: templates/pdf.html
+
+shift-heading-level-by: 1
+
+resource-path: ["images"]
+standalone: true
+
+pdf-engine: pagedjs-cli
+#pdf-engine-opts:
+#  - '--page-size [size]' # Print to Page Size [size]
+#  - '--width [size]' # Print to Page Width [width]
+#  - '--height [size]' # Print to Page Height [weight]
+#  - '--page-margin [margin]' # Print with margin [margin]
+
+# table of contents
+table-of-contents: true
+toc-depth: 3
+
+# section numbers
+number-sections: false
+
+# citations
+citeproc: true
+bibliography:
+  - references.bib
+
+# math, see https://pandoc.org/MANUAL.html#math-rendering-in-html
+html-math-method:
+  method: mathjax
+  url: "https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"
+
+# code blocks
+highlight-style: pygments
+preserve-tabs: true
+
+# lua filters for adding new environments
+filters:
+  - lib/lua/questions.lua

--- a/templates/epub.html
+++ b/templates/epub.html
@@ -50,7 +50,7 @@ $endif$
   $if(copyright.statement)$
   <span style="font-weight:bold">Copyright status:</span>s <a href="$copyright.statement-uri$">$copyright.statement$</a>
   $endif$
-  $date$ $copyright.holder$</p>
+  $publication-year$ $copyright.holder$</p>
 <p><span style="font-weight:bold">License:</span> <a href="$copyright.license-uri$">$copyright.license$</a></p>
 
 $if(copyright.attribution)$

--- a/templates/epub.html
+++ b/templates/epub.html
@@ -50,7 +50,7 @@ $endif$
   $if(copyright.statement)$
   <span style="font-weight:bold">Copyright status:</span>s <a href="$copyright.statement-uri$">$copyright.statement$</a>
   $endif$
-  $publication-year$ $copyright.holder$</p>
+  $date$ $copyright.holder$</p>
 <p><span style="font-weight:bold">License:</span> <a href="$copyright.license-uri$">$copyright.license$</a></p>
 
 $if(copyright.attribution)$

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,12 +8,12 @@
 
     <title>$if(publisher)$$title$ | $publisher.name$$else$$title$$endif$</title>
 $for(author)$    <meta name="author" content="$if(author.name)$$author.name$$else$$author$$endif$" />$endfor$
-$if(date)$   <meta name="dcterms.date" content="$date$" />$endif$
+$if(publication-year)$   <meta name="dcterms.date" content="$publication-year$" />$endif$
 $if(keywords)$   <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />$endif$
 
     <!-- Bibliographic Metadata -->
     <meta name="citation_title" content="$title$">
-$if(date)$   <meta name="citation_year" content="$date$">$endif$
+$if(publication-year)$   <meta name="citation_year" content="$publication-year$">$endif$
     <meta name="citation_language" content="$lang$">
 $if(keyword)$$for(keyword)$     <meta name="citation_keywords" content="$keyword$">$endfor$$endif$
 $if(publisher)$     <meta name="citation_publisher" content="$publisher.name$">$endif$
@@ -46,7 +46,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
             "name": "$title$",
             "author": "$for(author)$$if(author.name)$$author.name$$else$$author$$endif$$sep$, $endfor$",
             "url": "$url$",
-            "datePublished": "$date$"
+            "datePublished": "$publication-year$"
         }
     </script>
 
@@ -143,7 +143,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
 
                         <dt>Copyright</dt>
                         <dd>$if(copyright.statement-uri)$
-                            <a href="$copyright.statement-uri$">$date$ &copy; 
+                            <a href="$copyright.statement-uri$">$publication-year$ &copy; 
                                 $if(copyright.holder)$
                                 $copyright.holder$
                                 $elseif(author.name)$
@@ -155,7 +155,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
                                 $endif$
                             </a>
                             $else$
-                            $date$ &copy; 
+                            $publication-year$ &copy; 
                                 $if(copyright.holder)$$copyright.holder$$endif$
                                 $if(author.name)$
                                 $for(author)$
@@ -181,7 +181,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
                         $if(copyright.attribution)$
                         <dt>Preferred Attribution</dt>
                         <dd>$if(copyright.attribution)$$copyright.attribution$$else$$for(author)$$author.name$$sep$, $endfor$, <em><a ref="$url$">$title$ $if(subtitle)$: $subtitle$$endif$.</a></em> $publisher.location$: <a href="$publisher-website$">$publisher.name$</a>,
-                            $date$.$endif$
+                            $publication-year$.$endif$
                         </dd>
                         $endif$
                     </dl>

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,12 +8,12 @@
 
     <title>$if(publisher)$$title$ | $publisher.name$$else$$title$$endif$</title>
 $for(author)$    <meta name="author" content="$if(author.name)$$author.name$$else$$author$$endif$" />$endfor$
-$if(publication-year)$   <meta name="dcterms.date" content="$publication-year$" />$endif$
+$if(date)$   <meta name="dcterms.date" content="$date$" />$endif$
 $if(keywords)$   <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />$endif$
 
     <!-- Bibliographic Metadata -->
     <meta name="citation_title" content="$title$">
-$if(publication-year)$   <meta name="citation_year" content="$publication-year$">$endif$
+$if(date)$   <meta name="citation_year" content="$date$">$endif$
     <meta name="citation_language" content="$lang$">
 $if(keyword)$$for(keyword)$     <meta name="citation_keywords" content="$keyword$">$endfor$$endif$
 $if(publisher)$     <meta name="citation_publisher" content="$publisher.name$">$endif$
@@ -46,7 +46,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
             "name": "$title$",
             "author": "$for(author)$$if(author.name)$$author.name$$else$$author$$endif$$sep$, $endfor$",
             "url": "$url$",
-            "datePublished": "$publication-year$"
+            "datePublished": "$date$"
         }
     </script>
 
@@ -143,7 +143,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
 
                         <dt>Copyright</dt>
                         <dd>$if(copyright.statement-uri)$
-                            <a href="$copyright.statement-uri$">$publication-year$ &copy; 
+                            <a href="$copyright.statement-uri$">$date$ &copy; 
                                 $if(copyright.holder)$
                                 $copyright.holder$
                                 $elseif(author.name)$
@@ -155,7 +155,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
                                 $endif$
                             </a>
                             $else$
-                            $publication-year$ &copy; 
+                            $date$ &copy; 
                                 $if(copyright.holder)$$copyright.holder$$endif$
                                 $if(author.name)$
                                 $for(author)$
@@ -181,7 +181,7 @@ $if(url)$    <meta property="twitter:domain" content="$url$">$endif$
                         $if(copyright.attribution)$
                         <dt>Preferred Attribution</dt>
                         <dd>$if(copyright.attribution)$$copyright.attribution$$else$$for(author)$$author.name$$sep$, $endfor$, <em><a ref="$url$">$title$ $if(subtitle)$: $subtitle$$endif$.</a></em> $publisher.location$: <a href="$publisher-website$">$publisher.name$</a>,
-                            $publication-year$.$endif$
+                            $date$.$endif$
                         </dd>
                         $endif$
                     </dl>

--- a/templates/lantern.context.tex
+++ b/templates/lantern.context.tex
@@ -183,13 +183,13 @@ $endfor$
 
 $description$
 \blank
-\copyright $date$ $if(copyright.holder)$$copyright.holder$$else$$for(author)$$author.name$$sep$, $endfor$$endif$. All rights reserved. $if(copyright.license)$
+\copyright $publication-year$ $if(copyright.holder)$$copyright.holder$$else$$for(author)$$author.name$$sep$, $endfor$$endif$. All rights reserved. $if(copyright.license)$
 Licensed under \goto{$copyright.license$}[url($copyright.license-uri$)]$endif$ $if(publisher)$Published by $publisher.name$$endif$
 \blank
 $if(copyright.attribution)$
 $copyright.attribution$
 $else$
-$for(author)$$author.name$$sep$, $endfor$. \it{$title$$if(subtitle)$: $subtitle$$endif$}. $if(publisher.location)$\tf{$publisher.location$: $endif$$publisher.name$, $date$.}
+$for(author)$$author.name$$sep$, $endfor$. \it{$title$$if(subtitle)$: $subtitle$$endif$}. $if(publisher.location)$\tf{$publisher.location$: $endif$$publisher.name$, $publication-year$.}
 $endif$
 
 \stopstandardmakeup

--- a/templates/lantern.context.tex
+++ b/templates/lantern.context.tex
@@ -1,3 +1,6 @@
+% DEPRECATED: earlier versions of Lantern supported ConTeXt, but no longer
+% leaving this here in case you prefer ConTeXt as your PDF engine
+
 $if(lang)$
 \mainlanguage[$lang$]
 $endif$

--- a/templates/lantern.context.tex
+++ b/templates/lantern.context.tex
@@ -183,13 +183,13 @@ $endfor$
 
 $description$
 \blank
-\copyright $publication-year$ $if(copyright.holder)$$copyright.holder$$else$$for(author)$$author.name$$sep$, $endfor$$endif$. All rights reserved. $if(copyright.license)$
+\copyright $date$ $if(copyright.holder)$$copyright.holder$$else$$for(author)$$author.name$$sep$, $endfor$$endif$. All rights reserved. $if(copyright.license)$
 Licensed under \goto{$copyright.license$}[url($copyright.license-uri$)]$endif$ $if(publisher)$Published by $publisher.name$$endif$
 \blank
 $if(copyright.attribution)$
 $copyright.attribution$
 $else$
-$for(author)$$author.name$$sep$, $endfor$. \it{$title$$if(subtitle)$: $subtitle$$endif$}. $if(publisher.location)$\tf{$publisher.location$: $endif$$publisher.name$, $publication-year$.}
+$for(author)$$author.name$$sep$, $endfor$. \it{$title$$if(subtitle)$: $subtitle$$endif$}. $if(publisher.location)$\tf{$publisher.location$: $endif$$publisher.name$, $date$.}
 $endif$
 
 \stopstandardmakeup

--- a/templates/lantern.latex.tex
+++ b/templates/lantern.latex.tex
@@ -1,3 +1,6 @@
+% DEPRECATED: earlier versions of Lantern supported LaTeX, but no longer
+% leaving this here in case you prefer LaTeX as your PDF engine
+
 \documentclass{book}
 
 \title{$title$}

--- a/templates/lantern.latex.tex
+++ b/templates/lantern.latex.tex
@@ -159,7 +159,7 @@ $endif$
 
 \begin{flushleft}
 
-\textbf{Copyright \textcopyright{} $date$  $copyright.holder$\\
+\textbf{Copyright \textcopyright{} $publication-year$  $copyright.holder$\\
 License: \booklicense}\\[11pt] 
 
 $if(copyright.exceptions)$
@@ -185,7 +185,7 @@ For permissions beyond the scope of this license, visit $publisher.website$
 \begin{description}
   \item[Recommended Citation] \hfill \\ $copyright.attribution$
   \item[Publisher] \hfill \\ $publisher.name$, $publisher.location$
-  \item[Date] \hfill \\ $date$
+  \item[Date] \hfill \\ $publication-year$
   $if(website)$
   \item[Website] \hfill \\ $website$
   $endif$

--- a/templates/lantern.latex.tex
+++ b/templates/lantern.latex.tex
@@ -159,7 +159,7 @@ $endif$
 
 \begin{flushleft}
 
-\textbf{Copyright \textcopyright{} $publication-year$  $copyright.holder$\\
+\textbf{Copyright \textcopyright{} $date$  $copyright.holder$\\
 License: \booklicense}\\[11pt] 
 
 $if(copyright.exceptions)$
@@ -185,7 +185,7 @@ For permissions beyond the scope of this license, visit $publisher.website$
 \begin{description}
   \item[Recommended Citation] \hfill \\ $copyright.attribution$
   \item[Publisher] \hfill \\ $publisher.name$, $publisher.location$
-  \item[Date] \hfill \\ $publication-year$
+  \item[Date] \hfill \\ $date$
   $if(website)$
   \item[Website] \hfill \\ $website$
   $endif$

--- a/templates/oai.xml
+++ b/templates/oai.xml
@@ -7,7 +7,7 @@ $for(author)$
     <dc:creator>$author.name$</dc:creator>
 $endfor$
     <dc:publisher>$publisher.name$</dc:publisher>
-    <dc:date>Created: $publication-year$</dc:date>
+    <dc:date>Created: $date$</dc:date>
     <dc:type>text</dc:type>
     <dc:identifier>$doi$</dc:identifier>
     <dc:identifier>$isbn-p$</dc:identifier>

--- a/templates/oai.xml
+++ b/templates/oai.xml
@@ -7,7 +7,7 @@ $for(author)$
     <dc:creator>$author.name$</dc:creator>
 $endfor$
     <dc:publisher>$publisher.name$</dc:publisher>
-    <dc:date>Created: $date$</dc:date>
+    <dc:date>Created: $publication-year$</dc:date>
     <dc:type>text</dc:type>
     <dc:identifier>$doi$</dc:identifier>
     <dc:identifier>$isbn-p$</dc:identifier>

--- a/templates/pdf.html
+++ b/templates/pdf.html
@@ -15,8 +15,8 @@
       <h2>$subtitle$</h2>
       $endif$
       
+      $if(author)$
       <div class="authors">
-        $if(author)$
         <p>
           $for(author)$$if(author.name)$$author.name$$else$$author$$endif$$sep$, $endfor$
         </p>
@@ -37,6 +37,7 @@
     
     </div>
 
+    $if(copyright)$
     <div id="copyright" class="copyright-page">
 
       <h2>$publisher.name$</h2>
@@ -59,6 +60,7 @@
       <p>ISBN: $isbn-e$ Electronic</p>
 
     </div>
+    $endif$
 
     <div id="toc" class="table-of-contents">
 

--- a/templates/pdf.html
+++ b/templates/pdf.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>$title$</title>
+    <link rel="stylesheet" href="lib/css/pdf.css">
+  </head>
+  <body>
+
+    <div id="title" class="title-page">
+
+      <h1>$title$</h1>
+      
+      $if(subtitle)$
+      <h2>$subtitle$</h2>
+      $endif$
+      
+      <div class="authors">
+        $if(author)$
+        <p>
+          $for(author)$$if(author.name)$$author.name$$else$$author$$endif$$sep$, $endfor$
+        </p>
+      </div>
+      $endif$
+
+      $if(publisher)$
+      <div class="publisher">
+        <a href="$publisher.website$">$publisher.name$</a>
+      </div>
+      $endif$
+      
+      $if(date)$
+      <div class="date">
+        $date$
+      </div>
+      $endif$
+    
+    </div>
+
+    <div id="copyright" class="copyright-page">
+
+      <h2>$publisher.name$</h2>
+      <p>$publisher.location$, $publisher.website$</p>
+
+      <p>Copyright &copy; $date$ by The Authors.</p>
+
+      <a href="$copyright.license-uri$">
+          $copyright.license$
+      </a>
+
+      $if(copyright.attribution)$
+      <p>
+        $copyright.attribution$
+      </p>
+      $endif$
+
+      <p>DOI: $doi$</p>
+      <p>ISBN: $isbn-p$ Hardback</p>
+      <p>ISBN: $isbn-e$ Electronic</p>
+
+    </div>
+
+    <div id="toc" class="table-of-contents">
+
+      $if(toc)$
+      <nav id="$idprefix$TOC" role="doc-toc">
+      $if(toc-title)$
+      <h2 id="$idprefix$toc-title">$toc-title$</h2>
+      $endif$
+      $table-of-contents$
+      </nav>
+      $endif$
+
+    </div>
+
+    <main>
+      $body$
+    </main>
+
+
+  </body>
+</html>


### PR DESCRIPTION
Pandoc now supports [PagedJS](https://pagedjs.org/) as a PDF engine, which means we can style PDFs according to HTML and CSS rules. This is **much** simpler than styling PDFs with LaTeX or ConTeXt. Perhaps more importantly, I believe `pagedjs-cli` will be easier to install across operating systems and development environments than TeX-based systems. 

- PDF template --> `templates/pdf.html`
- PDF styles --> `lib/css/pdf.css`
- PDF pandoc settings --> `settings/pdf.yml`